### PR TITLE
Fix: Disable hypridle auto-lock for KVM switching

### DIFF
--- a/hypr/.config/hypr/hypridle.conf
+++ b/hypr/.config/hypr/hypridle.conf
@@ -4,15 +4,18 @@ general {
     after_sleep_cmd = hyprctl dispatch dpms on  # avoids having to press a key twice to turn on the display
 }
 
-# === HYPRIDLE: SCREENLOCK
-listener {
-    timeout = 600 # 10 mins
-    on-timeout = loginctl lock-session
-}
+# === HYPRIDLE: SCREENLOCK (disabled for KVM switching)
+# Auto-lock disabled to prevent wake issues when switching back from MacBook via KVM
+# Lock manually with $mod+L keybind when needed
+# listener {
+#     timeout = 600 # 10 mins
+#     on-timeout = loginctl lock-session
+# }
 
 # === HYPRIDLE: DPMS
+# Display will turn off after 15 minutes but system stays unlocked for easy KVM switching
 listener {
-    timeout = 660 # 11 mins
+    timeout = 900 # 15 mins
     on-timeout = hyprctl dispatch dpms off
     on-resume = hyprctl dispatch dpms on
 }


### PR DESCRIPTION
## Summary
- Disables automatic screen locking in hypridle to resolve wake issues when switching back from MacBook via KVM
- Extends DPMS timeout from 11 to 15 minutes
- Manual lock still available via $mod+L keybind

## Changes
- Commented out auto-lock listener in `hypridle.conf`
- Added explanatory comments about KVM switching context
- Increased display timeout to 15 minutes for better usability

## Test plan
- [x] Verify display turns off after 15 minutes of inactivity
- [x] Confirm system remains unlocked after display timeout
- [x] Test KVM switching doesn't trigger unwanted locks
- [x] Verify manual lock ($mod+L) still works