### PR TITLE
feat(pi-agents): add destructive command guard section (vercel env pull, migrations, deploys)

### DIFF
--- a/pi/.pi/agent/AGENTS.md
+++ b/pi/.pi/agent/AGENTS.md
@@ -110,6 +110,49 @@ Pi spawns. Do not:
 If a secret is missing, the source of truth is the `env.op` manifest. Add an
 `op://` reference there.
 
+## Destructive command guard
+
+Agents must not invoke commands that overwrite or destroy local state without
+explicit user instruction in the active turn. The most common traps:
+
+### `vercel env pull` is forbidden
+
+**Never run `vercel env pull`, `vercel env pull --overwrite`, or any variant.**
+The command writes to `.env.local` by default and will clobber whatever is
+there — including 1Password-injected values, locally-configured DATABASE_URLs,
+feature flags, and dev-only overrides. The clobber is silent and complete; the
+file is rewritten, not merged.
+
+If an agent needs to know what env vars exist in a Vercel project, use
+`vercel env ls` (read-only listing of keys + scopes, no values, no file writes)
+or the Vercel dashboard. There is no legitimate agent-driven use case for
+`vercel env pull` in this machine's setup — 1Password is the source of truth
+for secrets and the dashboard is the source of truth for project config.
+
+### Other destructive patterns
+
+Similar discipline applies to:
+
+- **Database migrations / schema mutations** — `pnpm db:migrate`, `db:push`,
+  `drizzle-kit push`, `prisma db push`, raw `psql` writes against `DATABASE_URL`.
+  These hit whichever DB the env points at. Default in many repos is
+  production. Project-level `AGENTS.md` (e.g. `~/dev/gtm/docs/db/local-development.md`)
+  has the per-project rules; the global principle is *never apply a migration
+  the user did not ask for in this turn*.
+- **Deployments** — `vercel deploy`, `vercel --prod`, `pnpm deploy`, anything
+  that ships code beyond the local workspace. Never invoke without an explicit
+  user instruction in the current turn.
+- **Package publishes** — `npm publish`, `pnpm publish`, `bun publish`.
+- **Force-push and history rewrites** — `git push --force`, `git push --force-with-lease`,
+  `git reset --hard origin/...`, interactive rebase that would lose local commits.
+  Always confirm with the user before any operation that could lose work.
+
+Generating a migration *file* (`drizzle-kit generate`, `prisma migrate dev --create-only`)
+is fine — the file is reviewable artifact. Applying it is the line.
+
+When in doubt, ask. The cost of a confirmation round-trip is much smaller than
+the cost of a clobbered `.env.local` or an unintended prod deploy.
+
 ## Shell behavior
 
 Pi runs `bash -c` non-interactively. User shell aliases (`cat=bat`, `ls=eza`)


### PR DESCRIPTION
Adds a "Destructive command guard" section to `~/.pi/agent/AGENTS.md` codifying three rules that came up across recent sessions but weren't previously written down at the global tier.

## What changed

New section between `## Secrets` and `## Shell behavior` covering:

1. **`vercel env pull` is forbidden** — absolute rule with the rationale (silent `.env.local` clobber, no legitimate agent use case on this machine). Read-only inspection via `vercel env ls` or the Vercel dashboard is the alternative.

2. **General destructive patterns** — `db:migrate` / `db:push` / `prisma db push`, deployments, package publishes, force-push and history rewrites. Each has a one-liner principle. Project-level `AGENTS.md` still owns per-repo nuance.

3. **What's still allowed** — generating migration files (`drizzle-kit generate`, `prisma migrate dev --create-only`). The file is a reviewable artifact; applying it is the line.

## Why

Surfaced during interview-bench prep (`~/dev/forge` slice-1 work). The bench's task descriptions need to forbid `vercel env pull` and `db:migrate`-shaped operations because the bench runs forge against repos that *do* point at production envs by default (per gtm's `docs/db/local-development.md` — "local dev runs against the production Neon database by default").

Two reasons to put this at the global tier rather than just in the bench task descriptions:

- **`vercel env pull` is universally wrong on this machine.** 1Password is the source of truth for secrets, and any `.env.local` is a curated override stack. Pulling Vercel state overwrites that curation silently and completely.
- **The patterns generalize.** The bench is one venue; any agent session that touches state-mutating commands in unfamiliar repos has the same risk surface. Codifying once at the global tier is cheaper than restating per-bench / per-task / per-PR.

## Relationship to existing repo-level rules

`~/dev/gtm/AGENTS.md` already has a softer "until further notice" framing around `vercel env add/rm/pull --overwrite` but explicitly allows bare `vercel env pull` for "read-only inspection." This PR makes the bare form globally forbidden — the gtm rule should eventually be updated to defer to the global one, but that's a follow-up, not blocking.

No code changes; documentation only.

## Verification

```
git diff --stat
 pi/.pi/agent/AGENTS.md | 43 +++++++++++++++++++++++++++++++++++++++++++
```

Section renders correctly when previewed; structure matches the rest of the file (h2 + h3 subsections, consistent prose voice).
