### PR TITLE
feat(claude): track global CLAUDE.md + mirror destructive command guard

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -1,0 +1,64 @@
+# Global Memory
+
+Loaded by Claude Code and any Agent SDK invocation that uses the
+`claude_code` preset (including `forge run` via `@anthropic-ai/claude-agent-sdk`).
+Project-level `CLAUDE.md` / `AGENTS.md` files extend or override these
+rules.
+
+## Destructive command guard
+
+Never invoke commands that overwrite or destroy local/remote state
+without explicit user instruction in the active turn.
+
+### `vercel env pull` is forbidden
+
+**Never run `vercel env pull`, `vercel env pull --overwrite`, or any
+variant.** The command writes to `.env.local` by default and will
+clobber whatever is there — including 1Password-injected values,
+locally-configured DATABASE_URLs, feature flags, and dev-only overrides.
+The clobber is silent and complete; the file is rewritten, not merged.
+
+If you need to know what env vars exist in a Vercel project, use
+`vercel env ls` (read-only listing of keys + scopes, no values, no file
+writes) or the Vercel dashboard. There is no legitimate agent-driven
+use case for `vercel env pull`.
+
+### Other destructive patterns
+
+Same discipline applies to:
+
+- **Database migrations / schema mutations** — `pnpm db:migrate`,
+  `db:push`, `drizzle-kit push`, `prisma db push`, raw `psql` writes
+  against `DATABASE_URL`. These hit whichever DB the env points at;
+  default in many repos is production. Project-level docs (e.g.
+  `docs/db/local-development.md` in gtm-style monorepos) own the
+  per-project rules; the global principle is *never apply a migration
+  the user did not ask for in this turn*.
+- **Deployments** — `vercel deploy`, `vercel --prod`, `pnpm deploy`,
+  anything that ships code beyond the local workspace. Never invoke
+  without an explicit user instruction in the current turn.
+- **Package publishes** — `npm publish`, `pnpm publish`, `bun publish`.
+- **Force-push and history rewrites** — `git push --force`,
+  `git push --force-with-lease`, `git reset --hard origin/...`,
+  interactive rebase that would lose local commits. Always confirm
+  with the user before any operation that could lose work.
+
+Generating a migration *file* (`drizzle-kit generate`,
+`prisma migrate dev --create-only`) is fine — the file is a reviewable
+artifact. *Applying* it is the line.
+
+When in doubt, ask. The cost of a confirmation round-trip is much
+smaller than the cost of a clobbered `.env.local` or an unintended
+prod deploy.
+
+## JSON Parsing
+
+**Don't use Python one-liners to parse JSON.** Use `jq` instead — it's
+more reliable and doesn't introduce a Python dependency.
+
+Good: `jq -r '.entries | map(select(.gitBranch == "main")) | sort_by(.modified) | reverse | .[:5][] | ...'`
+Bad: `cat file.json | python3 -c "import json, sys; ..."`
+
+Also avoid `jq` date math (`fromdateiso8601`) — it fails on ISO 8601
+timestamps with milliseconds. Stick to string comparison for dates
+(lexicographic sort works for ISO 8601).


### PR DESCRIPTION
Surfaced during forge interview-bench prep — the user caught a real gap: the destructive command rules from #9 went into `~/.pi/agent/AGENTS.md` (Pi's config path), but Pi's path is **not** the Claude Code memory hierarchy. Any Agent SDK invocation using the `claude_code` preset loads `~/.claude/CLAUDE.md`, not Pi's `AGENTS.md`.

For forge specifically: [src/core.ts:825](https://github.com/vieko/forge/blob/main/src/core.ts#L825) passes `systemPrompt: { type: 'preset', preset: 'claude_code', append: ... }` to the Agent SDK, which means **forge-spawned agents inherit `~/.claude/CLAUDE.md`** — not Pi's AGENTS.md. The PR #9 rules applied to direct Pi sessions but NOT to the agents forge spawns during a bench run.

Net: the safety story for the upcoming interview-bench round 2 was relying on task-description constraints alone for forge-spawned agents. This PR closes the gap.

## What changed

1. **Track `~/.claude/CLAUDE.md` in dotfiles.** Previously it was a real file outside version control (24 lines about jq vs python). The user already symlinks `~/.claude/settings.json` to `~/.dotfiles/claude/.claude/settings.json`; `CLAUDE.md` was the parity gap. After this PR:

   ```
   ~/.claude/CLAUDE.md  →  ../.dotfiles/claude/.claude/CLAUDE.md
   ```

2. **Mirror the destructive command guard into the new global CLAUDE.md.** Same content as #9 (vercel env pull forbidden + general destructive patterns + file-only artifact generation allowed), keyed to the audiences that read CLAUDE.md:

   - Claude Code direct sessions
   - Agent SDK invocations using the `claude_code` preset (forge, opencode, any tool built on `@anthropic-ai/claude-agent-sdk` with the preset)

   The existing jq-vs-python rule is preserved verbatim under a second section.

## Audiences and paths

| Agent | Reads | Source of truth |
|---|---|---|
| Pi sessions (this one) | `~/.pi/agent/AGENTS.md` | dotfiles `pi/.pi/agent/AGENTS.md` (#9) |
| Claude Code direct | `~/.claude/CLAUDE.md` | dotfiles `claude/.claude/CLAUDE.md` (this PR) |
| Agent SDK with `claude_code` preset (forge etc.) | `~/.claude/CLAUDE.md` | dotfiles `claude/.claude/CLAUDE.md` (this PR) |

Both paths converge on the same rules; drift risk is real and probably worth a follow-up that DRYs them up via shared content. For now the redundancy is acceptable while we figure out the factoring.

## Verification

```bash
ls -la ~/.claude/CLAUDE.md
# lrwxr-xr-x  ../.dotfiles/claude/.claude/CLAUDE.md
head -1 ~/.claude/CLAUDE.md
# # Global Memory
```

After merge, a fresh forge invocation should see the destructive-command rules in its system prompt via the `claude_code` preset loading `~/.claude/CLAUDE.md`.

## Why this matters for the bench

8 of the 8 round-2 bench tasks now have **defense in depth**:

1. Global Claude memory rules (this PR) apply to every agent the bench spawns.
2. Per-repo `AGENTS.md` / `CLAUDE.md` (where present — 6 of 8 repos have one) adds project-specific guidance.
3. Per-task constraints footer (in `tasks.json` from vieko/forge#242) re-states the rules in the active turn.

Layer 1 was the missing piece. Without it, the bench was relying on layers 2 + 3 alone, with layer 2 absent for 2 of the 8 repos (vlambeer, internal-agents/lead-bot, internal-agents/recon don't have AGENTS.md or CLAUDE.md).
